### PR TITLE
Add smithery.yaml for Smithery.ai listing

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,23 @@
+startCommand:
+  type: http
+  configSchema:
+    type: object
+    required:
+      - tenantSlug
+    properties:
+      tenantSlug:
+        type: string
+        title: Tenant Slug
+        description: Your Eve workspace tenant slug (found at evemem.com/app/overview)
+      apiKey:
+        type: string
+        title: API Key
+        description: Your Eve API key (create at evemem.com/app/overview)
+  commandFunction: |
+    (config) => ({
+      url: new URL(`https://mcp.evemem.com/mcp`),
+      headers: {
+        "X-Managed-Tenant-Slug": config.tenantSlug,
+        ...(config.apiKey ? { "Authorization": `Bearer ${config.apiKey}` } : {})
+      }
+    })


### PR DESCRIPTION
## Summary

- Adds `smithery.yaml` config file for listing Eve MCP on [Smithery.ai](https://smithery.ai)
- Configures remote HTTP endpoint with tenant slug and optional API key auth
- Smithery is a primary MCP server discovery directory

## After merging

1. Go to [smithery.ai/servers/new](https://smithery.ai/servers/new)
2. Submit `https://github.com/sherifkozman/eve-mcp` as the repo URL
3. Smithery will read the `smithery.yaml` and list Eve

## Test plan

- [ ] Verify smithery.yaml is valid YAML
- [ ] Verify the config matches Eve's auth format
- [ ] After submission, confirm Eve appears on Smithery search

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `smithery.yaml` to list the Eve MCP server on Smithery.ai, configuring an HTTP endpoint with tenant slug and optional API key auth. There is one correctness issue in the `commandFunction` that should be fixed before the listing will work reliably.

- **`url: new URL(...)`** returns a `URL` object; the Smithery `HttpMCPConfig` interface requires `url: string`. A `URL` object serializes to `{}` via `JSON.stringify`, so the connection URL would be silently dropped. Change it to a plain string literal.
- The `apiKey` is forwarded as `Authorization: Bearer`, but `examples/claude-code-mcp.json` uses `X-API-Key`. Confirm the Eve backend accepts the Bearer format before submitting to Smithery.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the `url: new URL(...)` bug will cause the Smithery listing to silently fail on connection.

The P1 finding (`url` being a `URL` object instead of a `string`) means the Smithery integration will not work correctly out of the box. JSON serialization of a URL object yields `{}`, so the connection URL is lost. The fix is a one-line change but it needs to happen before submission.

`smithery.yaml` — the `commandFunction` url field and auth header format both need attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| smithery.yaml | New Smithery listing config — `url` field returns a `URL` object instead of the required `string`, which will serialize to `{}` in JSON; auth header format also differs from existing examples. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (Smithery UI)
    participant S as Smithery Gateway
    participant E as Eve MCP (mcp.evemem.com/mcp)

    U->>S: Provide tenantSlug + (optional) apiKey
    S->>S: Evaluate commandFunction(config)
    Note over S: Returns { url, headers }
    S->>E: HTTP POST /mcp<br/>X-Managed-Tenant-Slug: {tenantSlug}<br/>Authorization: Bearer {apiKey} (if set)
    E-->>S: MCP Response
    S-->>U: Forward response
```

<sub>Reviews (1): Last reviewed commit: ["Add smithery.yaml for Smithery.ai MCP di..."](https://github.com/sherifkozman/eve-mcp/commit/743b7cb6fba2fa0ecc6ab5bfec0d9ca4e955bf4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28096539)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->