### PR TITLE
docs: add pip/pipx fallback (NAY-484)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ Use a tenant API key from the Eve admin panel.
 ```json
 {
   "eve-memory": {
-    "httpUrl": "https://mcp.evemem.com/mcp",
+    "type": "http",
+    "url": "https://mcp.evemem.com/mcp",
     "headers": {
       "X-API-Key": "eve_<tenant>_...",
       "X-Source-Agent": "claude_code"


### PR DESCRIPTION
Onboarding Audit found that requiring `uv tool install` introduces friction for non-Python devs. This PR adds explicit `pipx` and `pip install` fallbacks to the README to lower friction.