### PR TITLE
Merge preference-routing contract into main (union pointer for parent repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,11 @@ eve verify --tool codex-cli --auth-mode oauth
 
 ```bash
 eve memory search "what database do we use" --context naya
+eve memory search "which models do I prefer for UI work" --context personal --store preference
+eve memory search "which models do I prefer for UI work" --context personal --store preference --tool codex-cli
 eve memory search "auth patterns" --limit 5 --json
 eve memory status
+eve memory status --tool codex-cli
 eve memory status --json
 ```
 
@@ -249,12 +252,12 @@ X-Source-Agent = gemini_cli
 Codex should use an Eve-owned bearer token, not native `codex mcp login`.
 
 ```toml
-[mcp_servers.eve-memory]
+[mcp_servers."eve-memory"]
 url = "https://mcp.evemem.com/mcp"
 bearer_token_env_var = "EVE_CODEX_BEARER_TOKEN"
 startup_timeout_sec = 60
 
-[mcp_servers.eve-memory.headers]
+[mcp_servers."eve-memory".http_headers]
 X-Source-Agent = "codex_cli"
 ```
 

--- a/eve_client/auth/local_store.py
+++ b/eve_client/auth/local_store.py
@@ -81,7 +81,6 @@ class LocalCredentialStore(CredentialStore):
 
     def _set_secret(self, tool: ToolName, auth_mode: str, secret: str) -> CredentialRecord:
         key_name = self._key_name(tool, auth_mode)
-        label = "api-key" if auth_mode == "api-key" else auth_mode
         # Write to file store first (avoids keychain prompts on macOS).
         # Keyring is kept as secondary write for backward compat.
         if self.allow_file_fallback:

--- a/eve_client/cli.py
+++ b/eve_client/cli.py
@@ -44,8 +44,8 @@ from eve_client.lock import (
     installer_lock_is_held,
     read_lock_metadata,
 )
-from eve_client.memory_cli import memory_app
 from eve_client.manifest import ManifestIntegrityError, load_manifest
+from eve_client.memory_cli import memory_app
 from eve_client.oauth_device import (
     OAuthDeviceFlowError,
     poll_auth0_device_token,

--- a/eve_client/importer/__init__.py
+++ b/eve_client/importer/__init__.py
@@ -16,7 +16,12 @@ from eve_client.importer.models import (
     ImportSourceType,
     ImportTurn,
 )
-from eve_client.importer.upload import ImportUploadError, ImportUploadResult, build_batches_for_job, upload_run
+from eve_client.importer.upload import (
+    ImportUploadError,
+    ImportUploadResult,
+    build_batches_for_job,
+    upload_run,
+)
 
 __all__ = [
     "ImportBatch",

--- a/eve_client/memory_cli.py
+++ b/eve_client/memory_cli.py
@@ -22,25 +22,37 @@ console = Console()
 _SEARCH_PATH = "/memory/search"
 _HEALTH_PATH = "/health"
 _REQUEST_TIMEOUT = 30.0
+_SUPPORTED_TOOLS = ("claude-code", "gemini-cli", "codex-cli")
 
 
-def _get_auth_headers(config) -> dict[str, str]:  # noqa: ANN001
-    """Build auth headers from stored credentials.
+class AmbiguousMemoryAuthSelectionError(RuntimeError):
+    def __init__(self, tools: tuple[str, ...]) -> None:
+        self.tools = tools
+        super().__init__("multiple stored Eve credentials are available")
 
-    Tries OAuth bearer token first (with refresh if expired), then API key,
-    for each supported tool.
+
+def _tool_auth_precedence(tool_name: str) -> tuple[str, str]:
+    if tool_name in {"claude-code", "gemini-cli"}:
+        return ("api-key", "oauth")
+    return ("oauth", "api-key")
+
+
+def _auth_headers_for_tool(config, tool_name: str) -> dict[str, str]:  # noqa: ANN001
+    """Build auth headers for a single tool from stored credentials.
+
+    Uses tool-aware credential precedence and falls back to the other supported
+    credential type if the preferred one is unavailable.
     """
     import time
 
     store = LocalCredentialStore(
         config.state_dir, allow_file_fallback=config.allow_file_secret_fallback
     )
-    tools = ("claude-code", "gemini-cli", "codex-cli")
-    for tool_name in tools:
+
+    def _oauth_headers() -> dict[str, str]:
         try:
             session, _source = store.get_oauth_session(tool_name)  # type: ignore[arg-type]
             if session and session.access_token:
-                # Check if token is expired and refresh if possible
                 if session.expires_at and session.expires_at < time.time():
                     if session.refresh_token:
                         try:
@@ -51,18 +63,57 @@ def _get_auth_headers(config) -> dict[str, str]:  # noqa: ANN001
                             store.save_oauth_session(tool_name, refreshed)  # type: ignore[arg-type]
                             return {"Authorization": f"Bearer {refreshed.access_token}"}
                         except Exception:
-                            continue  # Try next tool
-                    else:
-                        continue  # Expired with no refresh token
+                            return {}
+                    return {}
                 return {"Authorization": f"Bearer {session.access_token}"}
         except CredentialStoreUnavailableError:
-            pass
+            return {}
+        return {}
+
+    def _api_key_headers() -> dict[str, str]:
         try:
             api_key, _source = store.get_api_key(tool_name)  # type: ignore[arg-type]
             if api_key:
                 return {"X-API-Key": api_key}
         except CredentialStoreUnavailableError:
-            pass
+            return {}
+        return {}
+
+    resolvers = {
+        "oauth": _oauth_headers,
+        "api-key": _api_key_headers,
+    }
+
+    for credential_kind in _tool_auth_precedence(tool_name):
+        headers = resolvers[credential_kind]()
+        if headers:
+            return headers
+    return {}
+
+
+def _get_auth_headers(config, tool_name: str | None = None) -> dict[str, str]:  # noqa: ANN001
+    """Build auth headers from stored credentials.
+
+    If a tool is provided, use only that tool's credentials.
+    Otherwise, require the credential set to be unambiguous.
+    """
+    if tool_name:
+        return _auth_headers_for_tool(config, tool_name)
+
+    matches: list[dict[str, str]] = []
+    matched_tools: list[str] = []
+    for candidate in _SUPPORTED_TOOLS:
+        headers = _auth_headers_for_tool(config, candidate)
+        if headers:
+            matches.append(headers)
+            matched_tools.append(candidate)
+
+    if len(matches) > 1:
+        raise AmbiguousMemoryAuthSelectionError(tuple(matched_tools))
+
+    if matches:
+        return matches[0]
+
     return {}
 
 
@@ -103,28 +154,55 @@ def search(
         "naya", "--context", "-c", help="Context scope (naya, personal, es)"
     ),
     store: str = typer.Option(
-        "semantic", "--store", "-s", help="Store to search (semantic, episodic, all)"
+        "semantic",
+        "--store",
+        "-s",
+        help="Store to search (semantic, episodic, preference, all)",
+    ),
+    tool: str | None = typer.Option(
+        None,
+        "--tool",
+        help="Credential source to use when multiple Eve client logins are configured (claude-code, gemini-cli, codex-cli)",
     ),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
 ) -> None:
     """Search memories via the Eve REST API."""
     _VALID_CONTEXTS = {"naya", "personal", "es"}
-    _VALID_STORES = {"semantic", "episodic", "all"}
+    _VALID_STORES = {"semantic", "episodic", "preference", "all"}
+    _VALID_TOOLS = set(_SUPPORTED_TOOLS)
     if context.lower() not in _VALID_CONTEXTS:
         raise typer.BadParameter(f"context must be one of {_VALID_CONTEXTS}, got '{context}'")
     if store.lower() not in _VALID_STORES:
         raise typer.BadParameter(f"store must be one of {_VALID_STORES}, got '{store}'")
+    if tool and tool.lower() not in _VALID_TOOLS:
+        raise typer.BadParameter(f"tool must be one of {_VALID_TOOLS}, got '{tool}'")
+    context = context.upper()
+    store = store.lower()
+    tool = tool.lower() if tool else None
     config = resolve_config()
-    auth_headers = _get_auth_headers(config)
+    try:
+        auth_headers = _get_auth_headers(config, tool)
+    except AmbiguousMemoryAuthSelectionError as exc:
+        joined_tools = ", ".join(exc.tools)
+        console.print(
+            "[yellow]Multiple stored credentials found for "
+            f"{joined_tools}. Re-run with `--tool` to choose one.[/yellow]"
+        )
+        raise typer.Exit(1)
     if not auth_headers:
-        console.print("[yellow]No stored credentials found. Run `eve auth login` first.[/yellow]")
+        if tool:
+            console.print(
+                f"[yellow]No stored credentials found for `{tool}`. Run `eve auth login --tool {tool}` first.[/yellow]"
+            )
+        else:
+            console.print("[yellow]No stored credentials found. Run `eve auth login` first.[/yellow]")
         raise typer.Exit(1)
 
     url = _api_base_url(config) + _SEARCH_PATH
     payload = {
         "query": query,
         "limit": limit,
-        "context": context.upper(),
+        "context": context,
         "store": store,
     }
     headers = {
@@ -185,6 +263,11 @@ def search(
 
 @memory_app.command()
 def status(
+    tool: str | None = typer.Option(
+        None,
+        "--tool",
+        help="Credential source to use when multiple Eve client logins are configured (claude-code, gemini-cli, codex-cli)",
+    ),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
 ) -> None:
     """Show memory service health and status."""
@@ -193,7 +276,19 @@ def status(
     headers = {"Accept": "application/json"}
 
     # Health endpoint is typically unauthenticated, but include auth if available
-    auth_headers = _get_auth_headers(config)
+    tool = tool.lower() if tool else None
+    if tool and tool not in _SUPPORTED_TOOLS:
+        raise typer.BadParameter(f"tool must be one of {set(_SUPPORTED_TOOLS)}, got '{tool}'")
+    try:
+        auth_headers = _get_auth_headers(config, tool)
+    except AmbiguousMemoryAuthSelectionError as exc:
+        joined_tools = ", ".join(exc.tools)
+        console.print(
+            "[yellow]Multiple stored credentials found for "
+            f"{joined_tools}. Continuing with an unauthenticated health request. "
+            "Re-run with `--tool` if you need a specific credential.[/yellow]"
+        )
+        auth_headers = {}
     headers.update(auth_headers)
 
     status_code, data = _http_request(url, headers=headers)

--- a/eve_client/merge.py
+++ b/eve_client/merge.py
@@ -301,10 +301,15 @@ def companion_content(tool: ToolName, mcp_base_url: str) -> str:
             "### Read discipline\n"
             "- Search Eve before claiming you do not know prior context.\n"
             "- Prefer Eve search over re-deciding something that may already have been decided.\n"
-            "- Use the memories already injected by hooks first; search again only when you need more.\n\n"
+            "- Use the memories already injected by hooks first; search again only when you need more.\n"
+            '- Use `memory_search(store="preference")` only for explicitly stored user, workflow/operating, behavior, or taste preferences.\n'
+            "- Keep project/team decisions, durable facts, architecture choices, and relationship lookup on semantic memory even if the wording includes prefer or favorite.\n"
+            "- Use episodic memory for session, event, or history recall.\n\n"
             "### Write discipline\n"
+            '- Use `memory_store(store="preference")` for stable user, workflow/operating, behavior, or taste preferences.\n'
             "- Store only durable, reusable information.\n"
             "- Do not write every intermediate thought or routine step.\n"
+            "- Store stable user, workflow/operating, behavior, or taste preferences in preference memory; keep project/team decisions, durable facts, and architecture choices in semantic memory; keep session/event recall in episodic memory.\n"
             "- Favor concise memories with enough detail to be useful later.\n\n"
             "### Session behavior\n"
             "- Treat Eve as the long-term memory layer, not as scratchpad storage.\n"
@@ -319,8 +324,13 @@ def companion_content(tool: ToolName, mcp_base_url: str) -> str:
             "- the user corrects or updates a durable fact or preference\n\n"
             "### Read discipline\n"
             "- Search Eve before assuming past context is unavailable.\n"
-            "- Reuse durable knowledge instead of re-deriving it.\n\n"
+            "- Reuse durable knowledge instead of re-deriving it.\n"
+            '- Use `memory_search(store="preference")` only for explicitly stored user, workflow/operating, behavior, or taste preferences.\n'
+            "- Keep project/team decisions, durable facts, architecture choices, and relationship lookup on semantic memory even if the wording includes prefer or favorite.\n"
+            "- Use episodic memory for session, event, or history recall.\n\n"
             "### Write discipline\n"
+            '- Use `memory_store(store="preference")` for stable user, workflow/operating, behavior, or taste preferences.\n'
+            "- Store stable user, workflow/operating, behavior, or taste preferences in preference memory; keep project/team decisions, durable facts, and architecture choices in semantic memory; keep session/event recall in episodic memory.\n"
             "- Store durable decisions, preferences, fixes, and notable outcomes.\n"
             "- Skip routine chatter and transient reasoning."
         ),
@@ -333,8 +343,13 @@ def companion_content(tool: ToolName, mcp_base_url: str) -> str:
             "- you want to preserve a useful outcome for a future session\n\n"
             "### Read discipline\n"
             "- Search Eve before saying prior context is missing.\n"
-            "- Prefer relevant existing memories over repeating discovery work.\n\n"
+            "- Prefer relevant existing memories over repeating discovery work.\n"
+            '- Use `memory_search(store="preference")` only for explicitly stored user, workflow/operating, behavior, or taste preferences.\n'
+            "- Keep project/team decisions, durable facts, architecture choices, and relationship lookup on semantic memory even if the wording includes prefer or favorite.\n"
+            "- Use episodic memory for session, event, or history recall.\n\n"
             "### Write discipline\n"
+            '- Use `memory_store(store="preference")` for stable user, workflow/operating, behavior, or taste preferences.\n'
+            "- Store stable user, workflow/operating, behavior, or taste preferences in preference memory; keep project/team decisions, durable facts, and architecture choices in semantic memory; keep session/event recall in episodic memory.\n"
             "- Store concise durable memories, not full transcripts.\n"
             "- Keep entries specific enough to be useful later."
         ),

--- a/tests/test_ide_integration.py
+++ b/tests/test_ide_integration.py
@@ -241,6 +241,10 @@ class TestCompanionPlacement:
         assert "### Read discipline" in content
         assert "### Write discipline" in content
         assert "### Session behavior" in content
+        assert 'memory_search(store="preference")' in content
+        assert 'memory_store(store="preference")' in content
+        assert "Use episodic memory for session, event, or history recall." in content
+        assert "Store stable user, workflow/operating, behavior, or taste preferences in preference memory;" in content
         assert "MCP endpoint: `https://mcp.evemem.com`" in content
 
     def test_claude_code_companion_appends_to_existing(self, tmp_path: Path) -> None:
@@ -334,6 +338,9 @@ class TestCompanionPlacement:
         assert "### Use Eve when" in content
         assert "### Read discipline" in content
         assert "### Write discipline" in content
+        assert 'memory_search(store="preference")' in content
+        assert 'memory_store(store="preference")' in content
+        assert "Store stable user, workflow/operating, behavior, or taste preferences in preference memory;" in content
 
     def test_gemini_cli_companion_appends_to_existing(self, tmp_path: Path) -> None:
         companion = tmp_path / "GEMINI.md"
@@ -487,6 +494,9 @@ class TestCompanionPlacement:
         assert "<!-- EVE-END:codex-cli:v1 -->" in content
         assert "## Eve Memory Protocol" in content
         assert "### Use Eve when" in content
+        assert 'memory_search(store="preference")' in content
+        assert 'memory_store(store="preference")' in content
+        assert "Store stable user, workflow/operating, behavior, or taste preferences in preference memory;" in content
 
     def test_codex_cli_companion_appends_to_existing_agents_md(self, tmp_path: Path) -> None:
         companion = tmp_path / "AGENTS.md"

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from eve_client import memory_cli
 from eve_client.cli import app
 from eve_client.config import ResolvedConfig
 from typer.testing import CliRunner
@@ -144,6 +145,39 @@ def _patch_config(tmp_path: Path):
 
 
 class TestMemorySearch:
+    def test_search_accepts_preference_store(self, tmp_path: Path) -> None:
+        captured: dict[str, object] = {}
+
+        def _urlopen(request, timeout=None):  # noqa: ANN001, ARG001
+            captured.update(json.loads(request.data.decode("utf-8")))
+            response = MagicMock()
+            response.status = 200
+            response.__enter__ = lambda s: s
+            response.__exit__ = lambda s, *a: None
+            response.read.return_value = json.dumps({"results": []}).encode("utf-8")
+            return response
+
+        with (
+            _patch_config(tmp_path),
+            _patch_auth_with_api_key(),
+            patch("eve_client.memory_cli.urllib.request.urlopen", side_effect=_urlopen),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "memory",
+                    "search",
+                    "which models do I prefer for UI work",
+                    "--store",
+                    "Preference",
+                    "--context",
+                    "personal",
+                ],
+            )
+            assert result.exit_code == 0
+            assert captured["store"] == "preference"
+            assert captured["context"] == "PERSONAL"
+
     def test_search_returns_results(self, tmp_path: Path) -> None:
         with (
             _patch_config(tmp_path),
@@ -223,8 +257,262 @@ class TestMemorySearch:
             assert result.exit_code == 1
             assert "Connection error" in result.stdout
 
+    def test_search_rejects_invalid_store(self, tmp_path: Path) -> None:
+        with (
+            _patch_config(tmp_path),
+            _patch_auth_with_api_key(),
+        ):
+            result = runner.invoke(app, ["memory", "search", "test", "--store", "graph"])
+            assert result.exit_code == 2
+            assert "Usage: eve memory search" in result.output
+            assert "Error" in result.output
+
+    def test_search_passes_explicit_tool_to_auth_lookup(self, tmp_path: Path) -> None:
+        with (
+            _patch_config(tmp_path),
+            patch("eve_client.memory_cli._get_auth_headers", return_value={"X-API-Key": "x"}) as auth_mock,
+            patch(
+                "eve_client.memory_cli.urllib.request.urlopen",
+                side_effect=_mock_urlopen(200, {"results": []}),
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["memory", "search", "what tone do I like", "--store", "preference", "--tool", "codex-cli"],
+            )
+            assert result.exit_code == 0
+            auth_mock.assert_called_once()
+            args, _kwargs = auth_mock.call_args
+            assert args[1] == "codex-cli"
+
+    def test_search_uses_oauth_header_for_codex_tool(self, tmp_path: Path) -> None:
+        captured_headers: dict[str, str] = {}
+
+        class _Store:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def get_oauth_session(self, tool_name):  # noqa: ANN001
+                if tool_name == "codex-cli":
+                    return MagicMock(access_token="oauth-token", expires_at=None), "keyring"
+                return None, None
+
+            def get_api_key(self, _tool_name):  # noqa: ANN001
+                return None, None
+
+        def _urlopen(request, timeout=None):  # noqa: ANN001, ARG001
+            captured_headers.update({key.lower(): value for key, value in request.header_items()})
+            response = MagicMock()
+            response.status = 200
+            response.__enter__ = lambda s: s
+            response.__exit__ = lambda s, *a: None
+            response.read.return_value = json.dumps({"results": []}).encode("utf-8")
+            return response
+
+        with (
+            _patch_config(tmp_path),
+            patch("eve_client.memory_cli.LocalCredentialStore", _Store),
+            patch("eve_client.memory_cli.urllib.request.urlopen", side_effect=_urlopen),
+        ):
+            result = runner.invoke(
+                app,
+                ["memory", "search", "what do I prefer", "--store", "preference", "--tool", "codex-cli"],
+            )
+            assert result.exit_code == 0
+            assert captured_headers["authorization"] == "Bearer oauth-token"
+
+    def test_search_uses_api_key_header_for_claude_tool(self, tmp_path: Path) -> None:
+        captured_headers: dict[str, str] = {}
+
+        class _Store:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def get_oauth_session(self, _tool_name):  # noqa: ANN001
+                return None, None
+
+            def get_api_key(self, tool_name):  # noqa: ANN001
+                if tool_name == "claude-code":
+                    return "claude-api-key", "keyring"
+                return None, None
+
+        def _urlopen(request, timeout=None):  # noqa: ANN001, ARG001
+            captured_headers.update({key.lower(): value for key, value in request.header_items()})
+            response = MagicMock()
+            response.status = 200
+            response.__enter__ = lambda s: s
+            response.__exit__ = lambda s, *a: None
+            response.read.return_value = json.dumps({"results": []}).encode("utf-8")
+            return response
+
+        with (
+            _patch_config(tmp_path),
+            patch("eve_client.memory_cli.LocalCredentialStore", _Store),
+            patch("eve_client.memory_cli.urllib.request.urlopen", side_effect=_urlopen),
+        ):
+            result = runner.invoke(
+                app,
+                ["memory", "search", "what tone do I like", "--store", "preference", "--tool", "claude-code"],
+            )
+            assert result.exit_code == 0
+            assert captured_headers["x-api-key"] == "claude-api-key"
+
+    def test_search_exits_when_credentials_are_ambiguous(self, tmp_path: Path) -> None:
+        with (
+            _patch_config(tmp_path),
+            patch(
+                "eve_client.memory_cli._get_auth_headers",
+                side_effect=memory_cli.AmbiguousMemoryAuthSelectionError(("claude-code", "codex-cli")),
+            ),
+        ):
+            result = runner.invoke(app, ["memory", "search", "what tone do I like"])
+            assert result.exit_code == 1
+            assert "Multiple stored credentials found" in result.output
+            assert "--tool" in result.output
+
+    def test_get_auth_headers_rejects_ambiguous_automatic_selection(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+
+        class _Store:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def get_oauth_session(self, tool_name):  # noqa: ANN001
+                if tool_name == "claude-code":
+                    return MagicMock(access_token="claude-token", expires_at=None), "keyring"
+                return None, None
+
+            def get_api_key(self, tool_name):  # noqa: ANN001
+                if tool_name == "codex-cli":
+                    return "codex-key", "keyring"
+                return None, None
+
+        with patch("eve_client.memory_cli.LocalCredentialStore", _Store):
+            with pytest.raises(memory_cli.AmbiguousMemoryAuthSelectionError) as exc:
+                memory_cli._get_auth_headers(config)
+            assert exc.value.tools == ("claude-code", "codex-cli")
+
+    def test_get_auth_headers_uses_requested_tool_only(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+
+        class _Store:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def get_oauth_session(self, tool_name):  # noqa: ANN001
+                if tool_name == "claude-code":
+                    return MagicMock(access_token="claude-token", expires_at=None), "keyring"
+                return None, None
+
+            def get_api_key(self, tool_name):  # noqa: ANN001
+                if tool_name == "codex-cli":
+                    return "codex-key", "keyring"
+                return None, None
+
+        with patch("eve_client.memory_cli.LocalCredentialStore", _Store):
+            assert memory_cli._get_auth_headers(config, "codex-cli") == {"X-API-Key": "codex-key"}
+
+    def test_get_auth_headers_prefers_api_key_for_claude_code(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+
+        class _Store:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def get_oauth_session(self, _tool_name):  # noqa: ANN001
+                return MagicMock(access_token="oauth-token", expires_at=None), "keyring"
+
+            def get_api_key(self, _tool_name):  # noqa: ANN001
+                return "api-key", "keyring"
+
+        with patch("eve_client.memory_cli.LocalCredentialStore", _Store):
+            assert memory_cli._get_auth_headers(config, "claude-code") == {"X-API-Key": "api-key"}
+
+    def test_get_auth_headers_prefers_oauth_for_codex(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+
+        class _Store:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def get_oauth_session(self, _tool_name):  # noqa: ANN001
+                return MagicMock(access_token="oauth-token", expires_at=None), "keyring"
+
+            def get_api_key(self, _tool_name):  # noqa: ANN001
+                return "api-key", "keyring"
+
+        with patch("eve_client.memory_cli.LocalCredentialStore", _Store):
+            assert memory_cli._get_auth_headers(config, "codex-cli") == {
+                "Authorization": "Bearer oauth-token"
+            }
+
+    def test_status_continues_unauthenticated_when_credentials_are_ambiguous(
+        self, tmp_path: Path
+    ) -> None:
+        with (
+            _patch_config(tmp_path),
+            patch(
+                "eve_client.memory_cli._get_auth_headers",
+                side_effect=memory_cli.AmbiguousMemoryAuthSelectionError(("claude-code", "codex-cli")),
+            ),
+            patch(
+                "eve_client.memory_cli.urllib.request.urlopen",
+                side_effect=_mock_urlopen(200, _HEALTH_OK),
+            ),
+        ):
+            result = runner.invoke(app, ["memory", "status"])
+            assert result.exit_code == 0
+            assert "unauthenticated health request" in result.output
+
 
 class TestMemoryStatus:
+    def test_status_with_explicit_tool_uses_auth_headers(self, tmp_path: Path) -> None:
+        captured_headers: dict[str, str] = {}
+
+        class _Store:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def get_oauth_session(self, tool_name):  # noqa: ANN001
+                if tool_name == "codex-cli":
+                    return MagicMock(access_token="oauth-token", expires_at=None), "keyring"
+                return None, None
+
+            def get_api_key(self, _tool_name):  # noqa: ANN001
+                return None, None
+
+        def _urlopen(request, timeout=None):  # noqa: ANN001, ARG001
+            captured_headers.update(dict(request.header_items()))
+            response = MagicMock()
+            response.status = 200
+            response.__enter__ = lambda s: s
+            response.__exit__ = lambda s, *a: None
+            response.read.return_value = json.dumps(_HEALTH_OK).encode("utf-8")
+            return response
+
+        with (
+            _patch_config(tmp_path),
+            patch("eve_client.memory_cli.LocalCredentialStore", _Store),
+            patch("eve_client.memory_cli.urllib.request.urlopen", side_effect=_urlopen),
+        ):
+            result = runner.invoke(app, ["memory", "status", "--tool", "codex-cli"])
+            assert result.exit_code == 0
+            assert captured_headers["Authorization"] == "Bearer oauth-token"
+
+    def test_status_with_explicit_tool_and_no_credentials_still_checks_health(
+        self, tmp_path: Path
+    ) -> None:
+        with (
+            _patch_config(tmp_path),
+            patch("eve_client.memory_cli._get_auth_headers", return_value={}),
+            patch(
+                "eve_client.memory_cli.urllib.request.urlopen",
+                side_effect=_mock_urlopen(200, _HEALTH_OK),
+            ),
+        ):
+            result = runner.invoke(app, ["memory", "status", "--tool", "claude-code"])
+            assert result.exit_code == 0
+
     def test_status_healthy(self, tmp_path: Path) -> None:
         with (
             _patch_config(tmp_path),

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -102,6 +102,10 @@ def test_companion_content_contains_markers() -> None:
     assert "## Eve Memory Protocol" in content
     assert "### Read discipline" in content
     assert "### Write discipline" in content
+    assert 'memory_search(store="preference")' in content
+    assert 'memory_store(store="preference")' in content
+    assert "Use episodic memory for session, event, or history recall." in content
+    assert "Store stable user, workflow/operating, behavior, or taste preferences in preference memory;" in content
 
 
 def test_merge_companion_file_appends_to_existing_agents_md(tmp_path: Path) -> None:

--- a/tests/test_state_binding.py
+++ b/tests/test_state_binding.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from eve_client.state_binding import (
     StateBindingError,
     clear_installation_id,


### PR DESCRIPTION
## What

Union merge `a0f1e4d`: `codex/client-preference-routing-contract` (11b414a0) → main (e3989b5a).

## Why

Resolves the parent-repo submodule divergence (eve decision **D4**, `tasks/branch-strategy-master-plan-v2-2026-06-05.md`): eve main pins `packages/client` at `11b414a0` (this contract branch, previously unmerged) while eve-mcp main advanced to `e3989b5a` (NAY-547 install.sh). Bumping the parent to either side alone would lose the other's work; this union makes main a superset so the parent can bump safely.

## Evidence

- `git merge-tree` predicted zero conflicts; actual merge clean (445 insertions, mostly contract tests)
- Test parity (same venv, both sides): baseline `e3989b5a` = 7 failed / 392 passed; union `a0f1e4d` = **same 7** / 405 passed — zero new failures, +13 passing contract tests
- The 7 shared failures are pre-existing `test_distribution.py` packaging-env tests (sdist/wheel build + install-script), unrelated to this merge

## Follow-ups

1. Parent repo PR bumping `packages/client` → this merge commit
2. CI smoke for `install.sh` (NAY-547) — separate slice

🤖 Generated with [Claude Code](https://claude.com/claude-code)