### PR TITLE
ci: install.sh smoke workflow (shellcheck + distribution tests)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,34 @@
+name: install.sh smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    name: shellcheck + syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: bash syntax check
+        run: bash -n install.sh
+      - name: shellcheck
+        run: |
+          sudo apt-get update -q && sudo apt-get install -y -q shellcheck
+          shellcheck install.sh
+
+  distribution-tests:
+    name: packaging + install-script tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[server]" build pytest pytest-asyncio
+      - name: run distribution suite (builds sdist/wheel, exercises install.sh)
+        run: pytest tests/test_distribution.py -q


### PR DESCRIPTION
Lane A follow-up (eve `master-plan-v2` D4 / NAY-547): adds the repo's first PR CI — `bash -n` + shellcheck on `install.sh`, plus `tests/test_distribution.py` (builds sdist/wheel and exercises the installer end-to-end in tmp dirs).

Note: the distribution suite showed 7 env-dependent failures on a local macOS dev box (missing packaging tooling); ubuntu-latest with `build` installed is the intended environment — if any fail here, that's signal, not noise.

Independent of #19 (based on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)